### PR TITLE
Add Vagrant Box for testing USB Gadgets in loopback with dummy_hcd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,9 @@ target
 
 # Mac
 .DS_Store
+
+# Vagrant Box
+.vagrant
+
+# Logs
+*.log

--- a/README.md
+++ b/README.md
@@ -10,3 +10,9 @@ cargo build --example hidecm
 
 # Demo
 [![asciicast](https://asciinema.org/a/4oc2n1za4o9nseny70ufjldo6.png)](https://asciinema.org/a/4oc2n1za4o9nseny70ufjldo6)
+
+# Vagrant
+
+A Vagrant box is available that pre-installs packages needed to compile a loopback dummy_hcd kernel module. Be aware that the provisioning step is a *two-step process* and requires a `vagrant reload` and execution of the script mentioned at the end of the first provision to build and install the kernel module.
+
+Before running the shell scripts accompanying the examples, run `sudo modprobe dummy_hcd` to load the loopback.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,39 @@
+# Vagrant Box for running USB Gadgets locally in a loopback and a Rust environment.
+
+Vagrant.configure("2") do |config|
+
+  config.vm.box = "ubuntu/zesty64"
+  config.vm.provision "shell", privileged: false, inline: <<-SHELL
+    sudo apt-get update
+    sudo apt-get install --no-install-recommends -y \
+      curl \
+      build-essential \
+      dpkg-dev \
+      bc \
+      libssl-dev \
+      linux-image-extra-virtual \
+      linux-headers-generic \
+
+    # curl for rustup.rs
+    # build-essential for ... essentials for building -*~stuff~*-
+    # dpkg-dev for downloading kernel source
+    # bc for Linux's `make prepare`
+    # libssl-dev for Linux's `make scripts`
+    # linux-image-extra-virtual since the default modules included don't
+    # include fun stuff like other gadgets
+    # linux-headers-generic for the module's build script
+
+    # setup 'rustup.sh'
+    sudo sh -c 'curl https://sh.rustup.rs -sSf > /usr/bin/rustup.sh'
+    sudo chmod +x /usr/bin/rustup.sh
+    # run 'rustup.sh'
+    /usr/bin/rustup.sh -y
+
+    # Unfortunately, two step provisions with a reboot require a plugin.
+    # Best to just leave it manually.
+    echo "The dummy_hcd kernel module enables USB loopback for gadgets."
+    echo "Unfortunately, Ubuntu/Debian does not build it, even in the 'extra' package."
+    echo "Run 'vagrant reload' on the host and then 'sudo /vagrant/scripts/build_dummy_hcd.sh' inside the vagrant VM to build and install dummy_hcd."
+    echo "This will have to be done on every kernel upgrade."
+  SHELL
+end

--- a/scripts/build_dummy_hcd.sh
+++ b/scripts/build_dummy_hcd.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+# Compile and Install the Dummy HCD driver which isn't pre-included.
+
+set -e
+
+if [ -f /var/run/reboot-required ]; then
+    echo "dummy_hcd Build Aborted. Reboot Required detected."
+    echo "Build dependent on building while running latest available kernel."
+    echo "Run 'vagrant reload' on the host."
+    exit 0
+fi
+
+KERNEL_RELEASE=$(uname -r)
+KERNEL_SHORT_VER=$(echo "$KERNEL_RELEASE" | cut -d"-" -f1)
+
+echo "Downloading Linux sources for $KERNEL_RELEASE and building dummy_hcd."
+
+apt-get source linux-image-"$KERNEL_RELEASE"
+cd linux-"$KERNEL_SHORT_VER" || exit
+cp /boot/config-"$KERNEL_RELEASE" .config
+cp /usr/src/linux-headers-"$KERNEL_RELEASE"/Module.symvers .
+sed -i -r 's/^(CONFIG_USB_DUMMY_HCD=.*|# CONFIG_USB_DUMMY_HCD is not set)/CONFIG_USB_DUMMY_HCD=m/' .config
+make prepare
+sed -i -r "s/^#define UTS_RELEASE \".*\"/#define UTS_RELEASE \"$KERNEL_RELEASE\"/" include/generated/utsrelease.h
+make scripts
+make M=drivers/usb/gadget/udc
+sudo cp drivers/usb/gadget/udc/dummy_hcd.ko /lib/modules/"$KERNEL_RELEASE"/kernel/drivers/usb/gadget/udc
+sudo depmod --all


### PR DESCRIPTION
Not everybody has a USB Gadget capable Linux computer on hand nor is it
always desirable to develop and test directly on "target" devices.

This Vagrant box provides a reproducible development environment with
USB Gadget Loopback support provided by dummy_hcd.

Unfortunately, dummy_hcd is not compiled by default in Ubuntu/Debian,
even in their "extra" package. We must compile and install it ourselves.
This Vagrant box tries to ease that process and make it easily
reproducible.

The vagrant box also contains Rust, so code in this repository can be
built, tested, and run.